### PR TITLE
fix: исправление push скриптов

### DIFF
--- a/scripts/lib/synchronize.js
+++ b/scripts/lib/synchronize.js
@@ -117,7 +117,8 @@ async function synchronize(source, target) {
   try {
     for (const item of createItems) {
       const newEntity = await target[item.type].createContent(item.path, item.content);
-      if (item.type === 'dashboards' && newEntity) await fromModule.createContent(item.path, newEntity);
+      // TODO: fromModule is undefined - this code was never working
+      // if (item.type === 'dashboards' && newEntity) await fromModule.createContent(item.path, newEntity);
       finalBar.increment();
     }
 

--- a/scripts/managers/DashboardManager.js
+++ b/scripts/managers/DashboardManager.js
@@ -123,7 +123,7 @@ class DashboardManager extends ContentManager {
 
   async createContent(path, content) {
     if (this.platform.type === 'server') {
-      [path, content] = this._prepareData(path, content);
+      [path, content] = this._prepareData(path, content, true);
     }
     const response = await this.platform.writeFile(path, content);
     return response && response.statusText === 'OK' ? response.data : null;
@@ -143,7 +143,7 @@ class DashboardManager extends ContentManager {
     await this.platform.deleteFile(path);
   }
 
-  _prepareData(path, content) {
+  _prepareData(path, content, isCreate = false) {
     const [schemaName, altId] = utils.splitResource(path);
     const tempArr = altId.split('/');
     const [topicName, dashboardName, fileName] = tempArr;
@@ -151,13 +151,13 @@ class DashboardManager extends ContentManager {
     let relativePath, id;
     if (fileName && !fileName.includes('index.json')) {
       id = fileName.substring(0, fileName.indexOf('.'));
-      relativePath = `dashlets/${id}`;
+      relativePath = isCreate ? 'dashlets' : `dashlets/${id}`;
     } else if (fileName && fileName.includes('index.json')) {
       id = dashboardName.substring(dashboardName.indexOf('.') + 1, dashboardName.length);
-      relativePath = `dashboards/${id}`;
+      relativePath = isCreate ? 'dashboards' : `dashboards/${id}`;
     } else if (dashboardName.includes('index.json')) {
       id = topicName.substring(topicName.indexOf('.') + 1, topicName.length);
-      relativePath = `dashboard_topics/${id}`;
+      relativePath = isCreate ? 'dashboard_topics' : `dashboard_topics/${id}`;
     }
 
     return [

--- a/scripts/managers/ResourceManager.js
+++ b/scripts/managers/ResourceManager.js
@@ -75,7 +75,7 @@ class ResourceManager extends ContentManager {
 
   createPath(schemaName, resource) {
     const fileName = typeof resource === 'string' ? resource : resource.alt_id;
-    if (fileName.startsWith('.cubes/') || fileName.startsWith('topic.')) return null;
+    if (fileName.startsWith('.cubes/') || fileName.startsWith('.cubes\\') || fileName.startsWith('topic.')) return null;
     return `/${schemaName}/${utils.encodePath(fileName)}`;
   }
 }


### PR DESCRIPTION
Исправил несколько багов в push скриптах:

**DashboardManager.js** — при создании дашборда POST запрос шёл с id в URL (`api/db/ds.dashboards/3`), что давало 404. Исправил формирование пути.

**synchronize.js** — закомментировал строку с `fromModule` — переменная нигде не определена, падало с ReferenceError.

**ResourceManager.js** — на Windows кубы из `.cubes/` попадали в resources вместо cubes. Проверка `fileName.startsWith('.cubes/')` не срабатывала, т.к. путь приходил с обратным слэшем: `.cubes\file.json`. Добавил проверку `.cubes\\`.